### PR TITLE
Make current state (here/away) more clear on search result page

### DIFF
--- a/client/templates/searchedPerson.html
+++ b/client/templates/searchedPerson.html
@@ -5,9 +5,13 @@
       <b>{{name}}</b>
       <form class="form-inline pull-right">
         {{#if joined}}
-          <button type="button" class="btn btn-primary btn-xs unjoin-one">here</button>
+        <label>Currently here
+        <button type="button" class="btn btn-primary btn-xs unjoin-one">mark away</button>
+        </label>
         {{else}}
-          <button type="button" class="btn btn-primary btn-xs join-one">away</button>
+        <label>Currently away
+        <button type="button" class="btn btn-primary btn-xs join-one">mark here</button>
+        </label>
         {{/if}}
       </form>
     </div>


### PR DESCRIPTION
Went to a pair columbus event today and there was a fair amount of confusion about how to set yourself as here/away. It's not immediately clear if the button shows your current state, or the state you will be in upon clicking the button. 

This PR adds a label which shows your current state, and makes the action the button will perform explicit.
