### PR TITLE
Clearfix for individuals in the signup view not making clean rows

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -29,3 +29,7 @@ h2 > .badge {
   font-size: 24px;
   padding-top: 7px;
 }
+
+.col-md-4:nth-child(3n+1) {
+  clear: left;
+}


### PR DESCRIPTION
Sadly, I neglected to take a screenshot of the problem, but the issue is that you have `n` of `.col-md-4` in  a container div, and heights of the `.col-md-4` are `w` with margin `m`:

```
1 2 3 
1 2 m
m 2
  m
```

The next item will appear thusly:

```
1 2 3 
1 2 m
m 2 4
  m 4
    m
5
5
m

```

This PR adds a `clear:left` to the first, fourth, seventh... `3n+1` objects so they don't catch on longer items to the left.
