### PR TITLE
Added a link for "About" and updated logo link

### DIFF
--- a/client/views/layout/navbar.html
+++ b/client/views/layout/navbar.html
@@ -1,4 +1,4 @@
-<template name="navbar">
+  <template name="navbar">
   <nav class="navbar navbar-default">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
@@ -9,7 +9,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="#">
+        <a class="navbar-brand" href="/">
           <img class="pair-columbus-logo" alt="Pair Columbus Logo" src="http://paircolumbus.org/images/logo-transparent.png" height="50px" width="90px" />
         </a>
         <p class="navbar-text"><strong>Pairs</strong> <small>Find other people to pair with based on shared interests and skills.</small></p>
@@ -18,6 +18,7 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav navbar-right">
+          <li><a class="btn btn-xs" href="/about">About</a></li>
           <li><a class="btn btn-xs" href="/contributing">Contributing</a></li>
           <li><a class="btn btn-xs" href="/contributors">Contributors</a></li>
           {{> loginButtons}}


### PR DESCRIPTION
Link for the existing “about” page is in the right section of the
navbar and updated the logo href to point to root instead of # as one
might expect.

Update to work in #70
